### PR TITLE
Duplicate check matches issue creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <jenkins.version>1.609.1</jenkins.version>
     <jira-rest-client.version>3.0.0</jira-rest-client.version>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <powermock.version>1.7.1</powermock.version>
   </properties>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -179,14 +180,40 @@
       <version>4.5.2</version>
     </dependency>
 
-
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.4</version>
     </dependency>
-
+	<dependency>
+		<groupId>org.mockito</groupId>
+		<artifactId>mockito-core</artifactId>
+		<version>2.8.47</version>
+		<scope>test</scope>
+	</dependency>
+   <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+   </dependency>
+   <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+   </dependency>
+	<dependency>
+		<groupId>junit</groupId>
+		<artifactId>junit</artifactId>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>spring-test</artifactId>
+		<version>4.0.5.RELEASE</version>
+		<scope>test</scope>
+	</dependency>
   </dependencies>
-
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -18,6 +18,7 @@ package org.jenkinsci.plugins.JiraTestResultReporter;
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.util.concurrent.Promise;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -251,7 +252,8 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
             }
 
             try {
-                String issueKey = JiraUtils.createIssueInput(project, test, testData.getEnvVars());
+                IssueInput issueInput = JiraUtils.createIssueInput(project, test, testData.getEnvVars());
+                String issueKey = JiraUtils.createIssue(issueInput);
                 return setIssueKey(issueKey);
             } catch (RestClientException e) {
                 JiraUtils.logError("Error when creating issue", e);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -29,7 +29,6 @@ import com.atlassian.util.concurrent.Promise;
 import hudson.*;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.*;
-import hudson.model.AbstractProject;
 import hudson.tasks.junit.*;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -54,6 +53,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -321,10 +321,11 @@ public class JiraTestDataPublisher extends TestDataPublisher
                         }
                         else
                         {
+                        	IssueInput issueInput = JiraUtils.createIssueInput(project, test, envVars);
                             boolean foundDuplicate = false;
                             if (JobConfigMapping.getInstance().getPreventDuplicateIssue(project))
                             {
-                                SearchResult searchResult = JiraUtils.findIssues(project, test, envVars);
+                                SearchResult searchResult = JiraUtils.findIssues(project, test, envVars, issueInput);
                                 if (searchResult != null)
                                 {
                                     for (Issue issue : searchResult.getIssues())
@@ -343,7 +344,7 @@ public class JiraTestDataPublisher extends TestDataPublisher
                             }
                             else
                             {
-                                String issueKey = JiraUtils.createIssueInput(project, test, envVars);
+                                String issueKey = JiraUtils.createIssue(issueInput);
                                 if (!JobConfigMapping.getInstance().getPreventDuplicateIssue(project))
                                 {
                                     TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issueKey);
@@ -865,4 +866,26 @@ public class JiraTestDataPublisher extends TestDataPublisher
                     .getDescriptorList(AbstractFields.class);
         }
     }
+
+//    public static void main(String [] args) {
+//    	//Jira URL = https://jira.intuit.com
+//    	//Username
+//    	//Password
+//    	//Default Summary = ${TEST_FULL_NAME} : ${TEST_ERROR_DETAILS}
+//    	//Default Description = ${BUILD_URL}${CRLF}${TEST_STACK_TRACE}
+//    	//String Field, Summary = ${TEST_FULL_NAME}
+//    	List<AbstractFields> configs = null;
+//        String projectKey = "TRAN";
+//        String issueType = "1";
+//        boolean autoRaiseIssue = true;
+//        boolean autoResolveIssue = false;
+//        boolean preventDuplicateIssue = true;
+//        String maxNoOfBugs = null;
+//    	JiraTestDataPublisher jtdp = new JiraTestDataPublisher(configs, projectKey, issueType, autoRaiseIssue, autoResolveIssue, preventDuplicateIssue, maxNoOfBugs);
+//    	
+//    	ItemGroup parent = new Jenkins();
+//    	String name = "testProject"
+//    	FreeStyleProject fsp = new FreeStyleProject();
+//    	jtdp.raiseIssues(new StreamBuildListener(System.out, Charset.defaultCharset()), project, job, envVars, testCaseResults);
+//    }
 }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -275,7 +275,7 @@ public class JiraTestDataPublisher extends TestDataPublisher
         }
     }
 
-    private void raiseIssues(TaskListener listener, AbstractProject project,
+    void raiseIssues(TaskListener listener, AbstractProject project,
             Job job, EnvVars envVars, List<CaseResult> testCaseResults)
     {
         for (CaseResult test : testCaseResults)
@@ -866,26 +866,4 @@ public class JiraTestDataPublisher extends TestDataPublisher
                     .getDescriptorList(AbstractFields.class);
         }
     }
-
-//    public static void main(String [] args) {
-//    	//Jira URL = https://jira.intuit.com
-//    	//Username
-//    	//Password
-//    	//Default Summary = ${TEST_FULL_NAME} : ${TEST_ERROR_DETAILS}
-//    	//Default Description = ${BUILD_URL}${CRLF}${TEST_STACK_TRACE}
-//    	//String Field, Summary = ${TEST_FULL_NAME}
-//    	List<AbstractFields> configs = null;
-//        String projectKey = "TRAN";
-//        String issueType = "1";
-//        boolean autoRaiseIssue = true;
-//        boolean autoResolveIssue = false;
-//        boolean preventDuplicateIssue = true;
-//        String maxNoOfBugs = null;
-//    	JiraTestDataPublisher jtdp = new JiraTestDataPublisher(configs, projectKey, issueType, autoRaiseIssue, autoResolveIssue, preventDuplicateIssue, maxNoOfBugs);
-//    	
-//    	ItemGroup parent = new Jenkins();
-//    	String name = "testProject"
-//    	FreeStyleProject fsp = new FreeStyleProject();
-//    	jtdp.raiseIssues(new StreamBuildListener(System.out, Charset.defaultCharset()), project, job, envVars, testCaseResults);
-//    }
 }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -15,10 +15,16 @@
  */
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
+
 import com.atlassian.jira.rest.client.api.IssueRestClient;
-import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
-import com.atlassian.jira.rest.client.api.SearchRestClient;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
@@ -31,15 +37,6 @@ import hudson.EnvVars;
 import hudson.model.AbstractProject;
 import hudson.tasks.test.TestResult;
 import jenkins.model.Jenkins;
-
-import org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.JiraTestDataPublisherDescriptor;
-import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Created by tuicu.
@@ -150,10 +147,7 @@ public class JiraUtils {
         fields.add("status");
         
         log(jql);
-        JiraTestDataPublisherDescriptor desc = JiraUtils.getJiraDescriptor();
-        JiraRestClient restClient = desc.getRestClient();
-        SearchRestClient searchClient = restClient.getSearchClient();
-        Promise<SearchResult> searchJqlPromise = searchClient.searchJql(jql, 50, 0, fields);
+        Promise<SearchResult> searchJqlPromise = JiraUtils.getJiraDescriptor().getRestClient().getSearchClient().searchJql(jql, 50, 0, fields);
         return searchJqlPromise.claim();
     }
     

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -16,7 +16,9 @@
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
 import com.atlassian.jira.rest.client.api.IssueRestClient;
+import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
+import com.atlassian.jira.rest.client.api.SearchRestClient;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
@@ -30,6 +32,7 @@ import hudson.model.AbstractProject;
 import hudson.tasks.test.TestResult;
 import jenkins.model.Jenkins;
 
+import org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.JiraTestDataPublisherDescriptor;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
 
 import java.util.HashSet;
@@ -147,7 +150,10 @@ public class JiraUtils {
         fields.add("status");
         
         log(jql);
-        Promise<SearchResult> searchJqlPromise = JiraUtils.getJiraDescriptor().getRestClient().getSearchClient().searchJql(jql, 50, 0, fields);
+        JiraTestDataPublisherDescriptor desc = JiraUtils.getJiraDescriptor();
+        JiraRestClient restClient = desc.getRestClient();
+        SearchRestClient searchClient = restClient.getSearchClient();
+        Promise<SearchResult> searchJqlPromise = searchClient.searchJql(jql, 50, 0, fields);
         return searchJqlPromise.claim();
     }
     

--- a/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JenkinsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JenkinsTest.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+
+import org.jvnet.hudson.reactor.ReactorException;
+
+import hudson.model.Hudson;
+
+public class JenkinsTest extends Hudson {
+
+	public JenkinsTest(File root, ServletContext context)
+			throws IOException, InterruptedException, ReactorException {
+		super(root, context);
+	}
+
+}


### PR DESCRIPTION
If the Summary field is overriden the duplicate check will not search for the same JIRA ticket data as what will get created.  This also has a couple minor changes to enable unit testing but before I can check-in the unit test(s) there is a change I need get merged to the junit-plugin project.